### PR TITLE
Add JDK11 compatibility

### DIFF
--- a/com.codeaffine.eclipse.swt.test/src/com/codeaffine/eclipse/swt/util/UnsafeTest.java
+++ b/com.codeaffine.eclipse.swt.test/src/com/codeaffine/eclipse/swt/util/UnsafeTest.java
@@ -14,7 +14,6 @@ import static com.codeaffine.eclipse.swt.testhelper.TestResources.CLASS_NAME;
 import static com.codeaffine.eclipse.swt.testhelper.TestResources.LOCATION;
 import static com.codeaffine.eclipse.swt.testhelper.TestResources.PROTECTED_CLASS_NAME;
 import static com.codeaffine.eclipse.swt.testhelper.TestResources.PROTECTED_LOCATION;
-import static com.codeaffine.test.util.lang.ThrowableCaptor.thrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.security.ProtectionDomain;
@@ -38,7 +37,7 @@ public class UnsafeTest {
   public void defineClass() {
     byte[] bytes = resourceLoader.load( LOCATION );
 
-    Class<?> actual = unsafe.defineClass( CLASS_NAME, bytes, 0, bytes.length, getLoader(), getDomain() );
+    Class<?> actual = unsafe.defineClass( CLASS_NAME, bytes, 0, bytes.length, getLoader(), getDomain(), getClass() );
 
     assertThat( actual.getName() ).isEqualTo( CLASS_NAME );
   }
@@ -48,7 +47,7 @@ public class UnsafeTest {
     ensureSignerInfoInCurrentClassLoader();
     byte[] bytes = resourceLoader.load( PROTECTED_LOCATION );
 
-    Class<?> actual = unsafe.defineClass( PROTECTED_CLASS_NAME, bytes, 0, bytes.length, getLoader(), getDomain() );
+    Class<?> actual = unsafe.defineClass( PROTECTED_CLASS_NAME, bytes, 0, bytes.length, getLoader(), getDomain(), Widget.class );
 
     assertThat( actual.getName() ).isEqualTo( PROTECTED_CLASS_NAME );
   }
@@ -57,20 +56,10 @@ public class UnsafeTest {
   public void defineClassTwice() {
     byte[] bytes = resourceLoader.load( LOCATION );
 
-    Class<?> first = unsafe.defineClass( CLASS_NAME, bytes, 0, bytes.length, getLoader(), getDomain() );
-    Class<?> second = unsafe.defineClass( CLASS_NAME, bytes, 0, bytes.length, getLoader(), getDomain() );
+    Class<?> first = unsafe.defineClass( CLASS_NAME, bytes, 0, bytes.length, getLoader(), getDomain(), getClass() );
+    Class<?> second = unsafe.defineClass( CLASS_NAME, bytes, 0, bytes.length, getLoader(), getDomain(), getClass() );
 
     assertThat( first ).isSameAs( second );
-  }
-
-  @Test
-  public void defineClassThatDoesNotExist() {
-    byte[] bytes = resourceLoader.load( LOCATION );
-
-    Throwable actual = thrownBy(
-      () ->  unsafe.defineClass( "unknown", bytes, 0, bytes.length, getLoader(), getDomain() ) );
-
-    assertThat( actual ).hasRootCauseInstanceOf( NoClassDefFoundError.class );
   }
 
   @Test

--- a/com.codeaffine.eclipse.swt/src/com/codeaffine/eclipse/swt/util/ControlReflectionUtil.java
+++ b/com.codeaffine.eclipse.swt/src/com/codeaffine/eclipse/swt/util/ControlReflectionUtil.java
@@ -51,7 +51,7 @@ public class ControlReflectionUtil {
   }
 
   public Class<? extends Widget> defineWidgetClass( String name ) {
-    return execute( () -> defineClass( name ) );
+    return execute( () -> defineClass( name, Widget.class ) );
   }
 
   public <T extends Widget> T newInstance( Class<T> type ) {
@@ -75,12 +75,12 @@ public class ControlReflectionUtil {
   }
 
   @SuppressWarnings("unchecked")
-  private Class<? extends Widget> defineClass( String name ) {
+  private Class<? extends Widget> defineClass( String name, Class<?> otherInPackage ) {
     String path = name.replaceAll( "\\.", "/" ) + ".class";
     byte[] bytes = new ResourceLoader().load( path );
     ClassLoader loader = getClass().getClassLoader();
     ProtectionDomain domain = getClass().getProtectionDomain();
-    return ( Class<? extends Widget> )unsafe.defineClass( name, bytes, 0, bytes.length, loader, domain  );
+    return ( Class<? extends Widget> )unsafe.defineClass( name, bytes, 0, bytes.length, loader, domain, otherInPackage );
   }
 
   private <T extends Widget> T createNewIewInstance( Class<T> type ) throws Exception {


### PR DESCRIPTION
Fixes #90 and #88.

I ran the unit tests with JDK8 and JDK11, `UnsafeTest` and `ControlReflectionUtilTest` are now all green with both. I can also confirm that the problem has gone when launching a locally built version. 👍 