### PR TITLE
Fix rendering issue of ruler numbers

### DIFF
--- a/com.codeaffine.eclipse.swt.test/src/com/codeaffine/eclipse/swt/widget/scrollable/StyledTextAdapterTest.java
+++ b/com.codeaffine.eclipse.swt.test/src/com/codeaffine/eclipse/swt/widget/scrollable/StyledTextAdapterTest.java
@@ -205,6 +205,19 @@ public class StyledTextAdapterTest {
     verify( listener, never() ).handleEvent( any( Event.class ) );
   }
 
+  @Test
+  public void hideNativeHorizontalScrollBarEvenIfResetToVisible() {
+    openShellWithoutLayout();
+    waitForReconciliation();
+
+    assertThat( styledText.getHorizontalBar().isVisible() ).isFalse();
+
+    styledText.getHorizontalBar().setVisible( true );
+    waitForReconciliation();
+
+    assertThat( styledText.getHorizontalBar().isVisible() ).isFalse();
+  }
+
   private void openShellWithoutLayout() {
     shell.setLayout( null );
     shell.open();

--- a/com.codeaffine.eclipse.swt/src/com/codeaffine/eclipse/swt/widget/scrollable/StyledTextAdapter.java
+++ b/com.codeaffine.eclipse.swt/src/com/codeaffine/eclipse/swt/widget/scrollable/StyledTextAdapter.java
@@ -313,6 +313,15 @@ public class StyledTextAdapter extends StyledText implements Adapter<StyledText>
 
   private void initialize() {
     styledText.setParent( this );
+    // Hide native horizontal bar to avoid rendering issues with neighbouring
+    // widgets (e.g. ruler, see https://github.com/fappel/xiliary/issues/87).
+    // External code trying to unhide it would trigger a PaintEvent, hence the
+    // listener to ensure it's always hidden.
+    styledText.addPaintListener( e -> {
+      if (styledText.getHorizontalBar() != null) {
+        styledText.getHorizontalBar().setVisible( false );
+      }
+    } );
     ScrollableControl<StyledText> scrollableControl = new ScrollableControl<>( styledText );
     context = new AdaptionContext<>( this, scrollableControl );
     reconciliation = context.getReconciliation();


### PR DESCRIPTION
Fixes  #87, or rather the ruler number part of it.

This fix came to light after further digging into what was done in https://git.eclipse.org/r/#/c/161336/

Screenshot of it in action:
![Screenshot (188)](https://user-images.githubusercontent.com/10694593/82023115-0ca6c580-968e-11ea-8220-48f083fd690b.png)

Two questions came to mind before submitting this pull request:
* should the same approach be applied to the vertical bar as well?
* should the same approach be applied to all adapted widgets, not just StyledText?

Given that I had no concrete example in mind that would benefit from either of the above, I decided to keep on the safe side and limit the scope of this fix.